### PR TITLE
Error handling and other improvements

### DIFF
--- a/Util/src/main/java/io/deephaven/util/referencecounting/ReferenceCounted.java
+++ b/Util/src/main/java/io/deephaven/util/referencecounting/ReferenceCounted.java
@@ -190,14 +190,20 @@ public abstract class ReferenceCounted implements LogOutputAppendable, Serializa
      * normally, but subsequent invocations of {@link #decrementReferenceCount()} and
      * {@link #tryDecrementReferenceCount()} will act as if the reference count was successfully decremented until
      * {@link #resetReferenceCount()} is invoked.
+     *
+     * @return Whether this invocation actually forced the reference count to zero (and invoked
+     *         {@link #onReferenceCountAtZero()}. {@code false} means that this ReferenceCounted reached a zero through
+     *         other means.
      */
-    public final void forceReferenceCountToZero() {
+    public final boolean forceReferenceCountToZero() {
         int currentReferenceCount;
         while (!isZero(currentReferenceCount = getCurrentReferenceCount())) {
             if (tryUpdateReferenceCount(currentReferenceCount, FORCED_TERMINAL_ZERO_VALUE)) {
                 onReferenceCountAtZero();
+                return true;
             }
         }
+        return false;
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -820,10 +820,10 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
 
         @ReferentialIntegrity
         private final Table parent;
-        private final BaseTable dependent;
+        private final BaseTable<?> dependent;
         private final boolean canReuseModifiedColumnSet;
 
-        public ListenerImpl(String description, Table parent, BaseTable dependent) {
+        public ListenerImpl(String description, Table parent, BaseTable<?> dependent) {
             super(description);
             this.parent = parent;
             this.dependent = dependent;
@@ -876,7 +876,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
             return parent;
         }
 
-        protected BaseTable getDependent() {
+        protected BaseTable<?> getDependent() {
             return dependent;
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableListenerBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableListenerBase.java
@@ -158,7 +158,7 @@ public abstract class InstrumentedTableListenerBase extends LivenessArtifact
 
     protected abstract void onFailureInternal(Throwable originalException, Entry sourceEntry);
 
-    protected final void onFailureInternalWithDependent(final BaseTable dependent, final Throwable originalException,
+    protected final void onFailureInternalWithDependent(final BaseTable<?> dependent, final Throwable originalException,
             final Entry sourceEntry) {
         dependent.notifyListenersOnError(originalException, sourceEntry);
 
@@ -168,7 +168,9 @@ public abstract class InstrumentedTableListenerBase extends LivenessArtifact
                 AsyncClientErrorNotifier.reportError(originalException);
             }
         } catch (IOException e) {
-            throw new UncheckedTableException("Exception in " + sourceEntry.toString(), originalException);
+            throw new UncheckedTableException(
+                    "Exception while delivering async client error notification for " + sourceEntry.toString(),
+                    originalException);
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
@@ -78,10 +78,9 @@ public class UnionSourceManager {
         // noinspection resource
         resultRows = RowSetFactory.empty().toTracking();
         unionRedirection = new UnionRedirection(initialNumSlots, refreshing);
-        // noinspection unchecked
         resultColumnSources = partitionedTable.constituentDefinition().getColumnStream()
                 .map(cd -> new UnionColumnSource<>(cd.getDataType(), cd.getComponentType(), this, unionRedirection,
-                        new TableSourceLookup(cd.getName())))
+                        new TableSourceLookup<>(cd.getName())))
                 .toArray(UnionColumnSource[]::new);
         resultTable = new QueryTable(resultRows, getColumnSources());
         modifiedColumnSet = resultTable.getModifiedColumnSetForUpdates();


### PR DESCRIPTION
1. Improve bucket and listener descriptions
2. Listen for transformation failures when bucketed
3. Ensure that source, transformation, and bucket failures are propagated, exactly once
4. Ensure that parallel execution costs are properly accumulated for performance logging
5. Fix some messages and warnings
6. Fix missing long cast